### PR TITLE
Add a newline at the end of /etc/timezone

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   # tzdata ignores debconf answers when configured non-interactively
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=704089
 - name: Configure timezone in /etc/timezone
-  copy: content='{{ ntp_timezone[0] + "/" + ntp_timezone[1] }}'
+  copy: content='{{ ntp_timezone[0] + "/" + ntp_timezone[1] }}\n'
         dest=/etc/timezone owner=root group=root mode=0644
   register: ntp_etc_timezone
   when: ntp_timezone is defined and ntp_timezone


### PR DESCRIPTION
Reconfigure tzdata modifies /etc/timezone and adds a newline at the end. then
Configure timezone in /etc/timezone sees the newline and overwrites it.

Without this change, every run has two changed steps.