### PR TITLE
Fix ntpd/openntpd install logic

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,11 +46,15 @@
 
   # Install NTPd on all hosts except inside containers
 - include: ntpd.yml
-  when: ((ntp_daemon == 'ntpd' or ntp == 'ntpd') and (ntp_install_daemon or (ansible_local|d() and ansible_local.cap12s|d() and
-         (not ansible_local.cap12s.enabled or 'cap_sys_time' in ansible_local.cap12s.list))))
+  when: ((ntp_daemon == 'ntpd' or ntp == 'ntpd') and
+         (ntp_install_daemon | bool or (ansible_local|d() and ansible_local.cap12s|d() and
+          (not ansible_local.cap12s.enabled | bool or
+           (ansible_local.cap12s.enabled | bool and 'cap_sys_time' in ansible_local.cap12s.list)))))
 
   # Install OpenNTPd on all hosts except inside containers
 - include: openntpd.yml
-  when: ((ntp_daemon == 'openntpd' or ntp == 'openntpd') and (ntp_install_daemon or (ansible_local|d() and ansible_local.cap12s|d() and
-         (not ansible_local.cap12s.enabled or 'cap_sys_time' in ansible_local.cap12s.list))))
+  when: ((ntp_daemon == 'openntpd' or ntp == 'openntpd') and
+         (ntp_install_daemon | bool or (ansible_local|d() and ansible_local.cap12s|d() and
+          (not ansible_local.cap12s.enabled | bool or
+           (ansible_local.cap12s.enabled | bool and 'cap_sys_time' in ansible_local.cap12s.list)))))
 


### PR DESCRIPTION
Now 'debops.ntpd' will correctly behave on systems with disabled POSIX
capabilities.