### PR TITLE
Check root flags for cap_sys_time status

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,10 +10,6 @@ ntp: 'openntpd'
 # and 'ntpd' is supported. Set to False to disable clock management
 ntp_daemon: 'openntpd'
 
-# Force installation of specified ntp daemon if Ansible did not detect the
-# environment correctly
-ntp_install_daemon: False
-
 # Timezone configuration
 # Specify timezone as 'Area/Zone', use 'dpkg-reconfigure tzdata' to see list of
 # possible values. To set the UTC timezone, specify it as 'Etc/UTC'
@@ -56,3 +52,11 @@ ntp_servers: [ '0.debian.pool.ntp.org',
 # NTPd specific.
 # Fudge local clock if time servers is not available
 ntp_fudge: True
+
+# List of global root flags to check
+ntp_root_flags:
+
+  # If these flags are present, ignore status of "cap_sys_time" capability and
+  # install specified ntp daemon
+  cap_sys_time: [ 'ignore-cap12s', 'ignore-cap_sys_time' ]
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,5 @@
 ---
 
-# Should ntp role manage timezone and ntp daemon on this host? Set to False to
-# disable
-# This variable is in transition period, use 'ntp_daemon' instead to specify
-# which daemon should be used.
-ntp: 'openntpd'
-
 # Which clock management daemon should be installed? Currently only 'openntpd'
 # and 'ntpd' is supported. Set to False to disable clock management
 ntp_daemon: 'openntpd'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,14 +46,14 @@
 
   # Install NTPd on all hosts except inside containers
 - include: ntpd.yml
-  when: ((ntp_daemon == 'ntpd' or ntp == 'ntpd') and (ansible_local|d() and
+  when: (ntp_daemon == 'ntpd' and (ansible_local|d() and
          (ansible_local.root|d() and (ansible_local.root.flags | intersect(ntp_root_flags.cap_sys_time)) or
          (ansible_local.cap12s|d() and (not ansible_local.cap12s.enabled | bool or
          (ansible_local.cap12s.enabled | bool and 'cap_sys_time' in ansible_local.cap12s.list))))))
 
   # Install OpenNTPd on all hosts except inside containers
 - include: openntpd.yml
-  when: ((ntp_daemon == 'openntpd' or ntp == 'openntpd') and (ansible_local|d() and
+  when: (ntp_daemon == 'openntpd' and (ansible_local|d() and
          (ansible_local.root|d() and (ansible_local.root.flags | intersect(ntp_root_flags.cap_sys_time)) or
          (ansible_local.cap12s|d() and (not ansible_local.cap12s.enabled | bool or
          (ansible_local.cap12s.enabled | bool and 'cap_sys_time' in ansible_local.cap12s.list))))))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,15 +46,15 @@
 
   # Install NTPd on all hosts except inside containers
 - include: ntpd.yml
-  when: ((ntp_daemon == 'ntpd' or ntp == 'ntpd') and
-         (ntp_install_daemon | bool or (ansible_local|d() and ansible_local.cap12s|d() and
-          (not ansible_local.cap12s.enabled | bool or
-           (ansible_local.cap12s.enabled | bool and 'cap_sys_time' in ansible_local.cap12s.list)))))
+  when: ((ntp_daemon == 'ntpd' or ntp == 'ntpd') and (ansible_local|d() and
+         (ansible_local.root|d() and (ansible_local.root.flags | intersect(ntp_root_flags.cap_sys_time)) or
+         (ansible_local.cap12s|d() and (not ansible_local.cap12s.enabled | bool or
+         (ansible_local.cap12s.enabled | bool and 'cap_sys_time' in ansible_local.cap12s.list))))))
 
   # Install OpenNTPd on all hosts except inside containers
 - include: openntpd.yml
-  when: ((ntp_daemon == 'openntpd' or ntp == 'openntpd') and
-         (ntp_install_daemon | bool or (ansible_local|d() and ansible_local.cap12s|d() and
-          (not ansible_local.cap12s.enabled | bool or
-           (ansible_local.cap12s.enabled | bool and 'cap_sys_time' in ansible_local.cap12s.list)))))
+  when: ((ntp_daemon == 'openntpd' or ntp == 'openntpd') and (ansible_local|d() and
+         (ansible_local.root|d() and (ansible_local.root.flags | intersect(ntp_root_flags.cap_sys_time)) or
+         (ansible_local.cap12s|d() and (not ansible_local.cap12s.enabled | bool or
+         (ansible_local.cap12s.enabled | bool and 'cap_sys_time' in ansible_local.cap12s.list))))))
 


### PR DESCRIPTION
By default 'debops.ntp' role will check if 'cap_sys_time' POSIX
capability is present and install specified NTP daemon if host can
change time. This can be overriden using "local root flags" to force
installation regardless of the POSIX capability status.