### PR TITLE
Make it simpler to comment out ntp servers.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,10 +38,12 @@ ntp_allow: []
 #                         5 -- 32 seconds
 #                         6 -- 64 seconds
 #                        and so on.
-ntp_servers: [ '0.debian.pool.ntp.org',
-               '1.debian.pool.ntp.org',
-               '2.debian.pool.ntp.org',
-               '3.debian.pool.ntp.org' ]
+
+ntp_servers:
+  - '0.debian.pool.ntp.org'
+  - '1.debian.pool.ntp.org'
+  - '2.debian.pool.ntp.org'
+  - '3.debian.pool.ntp.org'
 
 # NTPd specific.
 # Fudge local clock if time servers is not available


### PR DESCRIPTION
With this little change it is easier to comment out or change the list.
Example:

```YAML
ntp_servers:
  - '0.debian.pool.ntp.org'
  # - '1.debian.pool.ntp.org'
  - '2.debian.pool.ntp.org'
  - '3.debian.pool.ntp.org'
```