### PR TITLE
Fixed `ntp_listen: '*'` for NTPd.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,5 +11,7 @@ v0.1.0
 - Uninstall conflicting packages before installing the requested ones. This
   should fix `ntp and AppArmor issue`_ present in Ubuntu. [drybjed]
 
+- Fixed ``ntp_listen: '*'`` for NTPd. [ypid]
+
 .. _ntp and Apparmor issue: https://bugs.launchpad.net/ubuntu/+source/openntpd/+bug/458061
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,13 +1,13 @@
 ---
 
 # Which clock management daemon should be installed? Currently only 'openntpd'
-# and 'ntpd' is supported. Set to False to disable clock management
+# and 'ntpd' are supported. Set to False to disable clock management
 ntp_daemon: 'openntpd'
 
 # Timezone configuration
-# Specify timezone as 'Area/Zone', use 'dpkg-reconfigure tzdata' to see list of
+# Specify timezone as 'Area/Zone', use 'timedatectl list-timezones' to see list of
 # possible values. To set the UTC timezone, specify it as 'Etc/UTC'
-# If this variable is empty or False, timezone won't be changed
+# If this variable is empty or False, the timezone won't be changed
 ntp_timezone: ''
 
 # List of interfaces ntpd should listen on. Specify '*' to listen on all
@@ -18,7 +18,7 @@ ntp_listen: []
 ntp_firewall_access: False
 
 # List of hosts/networks in CIDR format to allow access to ntp port in
-# firewall. If this list is empty, access will be allowed from anywhere. You
+# firewall. If this list is False, access will be allowed from anywhere. You
 # should probably define a list of networks allowed access to mitigate NTP
 # amplification attacks
 ntp_allow: []
@@ -28,17 +28,16 @@ ntp_allow: []
 #   '0.debian.pool.ntp.org iburst minpoll 6 maxpoll 10'
 # If you're syncing against local servers, recommended options are --
 # 'burst iburst minpoll 4 maxpoll 4', where:
-#  - 'burst' and 'iburst' -- Get stratum as fast as possible by sending 8 sync
-#                            querys with 2 second interval. (Beware though,
+#  - 'burst' and 'iburst' -- Get a time sync as fast as possible by sending 8 sync
+#                            queries with 2 second interval. (Beware though,
 #                            this is considered as an abuse on public servers!)
-#  - minpoll, maxpoll -- Min/max interval for sync querys to be sent in normal
+#  - minpoll, maxpoll -- Min/max interval for sync queries to be sent in normal
 #                        operation mode. It's defined in seconds as a
 #                        power of two:
 #                         4 -- 16 seconds (minimal allowed)
 #                         5 -- 32 seconds
 #                         6 -- 64 seconds
 #                        and so on.
-
 ntp_servers:
   - '0.debian.pool.ntp.org'
   - '1.debian.pool.ntp.org'

--- a/templates/etc/ntpd/ntp.conf.j2
+++ b/templates/etc/ntpd/ntp.conf.j2
@@ -10,10 +10,10 @@ filegen loopstats file loopstats type day enable
 filegen peerstats file peerstats type day enable
 filegen clockstats file clockstats type day enable
 
+{% if ntp_listen is defined and ntp_listen and ntp_listen != '*' %}
 # Addresses to listen on, default is to block everything
 interface ignore ipv4
 interface ignore ipv6
-{% if ntp_listen is defined and ntp_listen %}
 {%   if ntp_listen is string %}
 interface listen {{ ntp_listen }}
 
@@ -73,4 +73,3 @@ restrict -6 {{ address|ipaddr('network') }} mask {{ address|ipaddr('netmask') }}
 restrict default limited kod nomodify notrap nopeer noquery
 restrict -6 default limited kod nomodify notrap nopeer noquery
 {% endif %}
-

--- a/templates/etc/ntpd/ntp.conf.j2
+++ b/templates/etc/ntpd/ntp.conf.j2
@@ -14,15 +14,15 @@ filegen clockstats file clockstats type day enable
 interface ignore ipv4
 interface ignore ipv6
 {% if ntp_listen is defined and ntp_listen %}
-{% if ntp_listen is string %}
+{%   if ntp_listen is string %}
 interface listen {{ ntp_listen }}
 
-{% else %}
-{% for address in ntp_listen %}
+{%   else %}
+{%     for address in ntp_listen %}
 interface listen {{ address }}
-{% endfor %}
+{%     endfor %}
 
-{% endif %}
+{%   endif %}
 {% else %}
 # ntpd will listen on all interfaces
 
@@ -53,21 +53,21 @@ restrict -6 ::1
 restrict default ignore
 restrict -6 default ignore
 
-{% if ntp_allow is string %}
-{% if ntp_allow|ipv4 %}
+{%   if ntp_allow is string %}
+{%     if ntp_allow|ipv4 %}
 restrict {{ ntp_allow|ipaddr('network') }} mask {{ ntp_allow|ipaddr('netmask') }} notrap nomodify nopeer
-{% else %}
+{%     else %}
 restrict -6 {{ ntp_allow|ipaddr('network') }} mask {{ ntp_allow|ipaddr('netmask') }} notrap nomodify nopeer
-{% endif %}
-{% else %}
-{% for address in ntp_allow %}
-{% if address|ipv4 %}
+{%     endif %}
+{%   else %}
+{%     for address in ntp_allow %}
+{%       if address|ipv4 %}
 restrict {{ address|ipaddr('network') }} mask {{ address|ipaddr('netmask') }} notrap nomodify nopeer
-{% else %}
+{%       else %}
 restrict -6 {{ address|ipaddr('network') }} mask {{ address|ipaddr('netmask') }} notrap nomodify nopeer
-{% endif %}
-{% endfor %}
-{% endif %}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
 {% else %}
 # No allow rules specified, so default is to allow everyone to query
 restrict default limited kod nomodify notrap nopeer noquery

--- a/templates/etc/openntpd/ntpd.conf.j2
+++ b/templates/etc/openntpd/ntpd.conf.j2
@@ -2,15 +2,15 @@
 
 {% if ntp_listen is defined and ntp_listen %}
 # Addresses to listen on
-{% if ntp_listen is string %}
+{%   if ntp_listen is string %}
 listen on {{ ntp_listen }}
 
-{% else %}
-{% for address in ntp_listen %}
+{%   else %}
+{%     for address in ntp_listen %}
 listen on {{ address }}
-{% endfor %}
+{%     endfor %}
 
-{% endif %}
+{%   endif %}
 {% else %}
 # ntpd is not listening on any interface
 


### PR DESCRIPTION
NTPd [ntpd](https://packages.debian.org/jessie/ntp) seems to behave a bit strange. When configured with:

    interface ignore ipv4
    interface ignore ipv6
    interface listen all

does not cause it to bind on v6 lo:

netstat -ulpen  |grep ntpd
udp        0      0 10.0.2.15:123           0.0.0.0:*                           0          25740       6353/ntpd
udp        0      0 127.0.0.1:123           0.0.0.0:*                           0          25739       6353/ntpd
udp6       0      0 fe80::a00:27ff:fe8b:123 :::*                                0          25741       6353/ntpd

Configuring it as:

    interface ignore ipv4
    interface ignore ipv6
    interface listen ipv6 all
    interface listen ipv4 all

would, but I suggest to use the default example from Debian in this case.

* NTPd does not understand a '*' as all. http://doc.ntp.org/4.2.6p5/miscopt.html#interface
* Removed double newline at the end of the file. Git (etckeeper) should this not so nice red + at the end of the file)
* Updated docs.