### PR TITLE
Dont remove ntp package when ntp__daemon=openntpd

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,7 +7,7 @@
     purge: True
   with_flattened:
     - [ '{{ "ntpdate" if (ntp__daemon != "ntpdate") else [] }}' ]
-    - [ '{{ "ntp" if (ntp__daemon != "ntpd") else [] }}' ]
+    - [ '{{ "ntp" if (ntp__daemon not in [ "ntpd", "openntpd"]) else [] }}' ]
     - [ '{{ "openntpd" if (ntp__daemon != "openntpd") else [] }}' ]
 
 - name: Install required packages


### PR DESCRIPTION
openntpd automatically remove the package if it is present, but fails to install if the ntp was "manually" removed.
